### PR TITLE
Semantic method assignment

### DIFF
--- a/src/lightning/structs.py
+++ b/src/lightning/structs.py
@@ -236,6 +236,17 @@ class Interface:
         resp.content = b''
         return resp
 
+    # register signatures for potential method definitions
+    get: Optional[Responsive]
+    post: Optional[Responsive]
+    put: Optional[Responsive]
+    delete: Optional[Responsive]
+    head: Optional[Responsive]
+    connect: Optional[Responsive]
+    trace: Optional[Responsive]
+    options: Optional[Responsive]
+    patch: Optional[Responsive]
+
     def __call__(self, *args, **kwargs):
         return self.process(*args, **kwargs)
 

--- a/src/lightning/structs.py
+++ b/src/lightning/structs.py
@@ -177,7 +177,7 @@ class Interface:
         else:
             raise ValueError(f'{obj} is not responsive nor callable')
 
-    def _select_method(self, request: Request) -> Sendable:
+    def _select_method(self, request: Request) -> Responsive:
         """Return a response which is produced by specified method in request"""
         method = request.method
         if method not in Method.__args__:
@@ -185,11 +185,11 @@ class Interface:
             return Response(400)  # incorrect request method
 
         if hasattr(self, method.lower()):
-            return getattr(self, method.lower())(request)
+            return getattr(self, method.lower())
         elif method in self.default_methods:
-            return self.default_methods[method](request)
+            return self.default_methods[method]
         else:
-            return self.generic(request)
+            return self.generic
 
     def find_methods(self):
         return tuple(m for m in Method.__args__ if hasattr(self, m.lower()))
@@ -214,7 +214,8 @@ class Interface:
             elif isinstance(res, Sendable):
                 return Response.create_from(res)
 
-        resp = Response.create_from(self._select_method(request))
+        handler = self._select_method(request)
+        resp = Response.create_from(handler(request))
         for pst in self.fpost:
             resp = Response.create_from(pst(request, resp))
         return resp

--- a/src/lightning/structs.py
+++ b/src/lightning/structs.py
@@ -140,8 +140,8 @@ class Interface:
 
     def __init__(self, get_or_method: Union[dict[Method, Responsive], Responsive] = None,
                  generic: Responsive = Response(405), fallback: Responsive = Response(500),
-                 pre: list[Callable[[Request], Union[Request, Sendable]]] = None,
-                 post: list[Callable[[Request, Response], Sendable]] = None,
+                 fpre: list[Callable[[Request], Union[Request, Sendable]]] = None,
+                 fpost: list[Callable[[Request, Response], Sendable]] = None,
                  desc: str = None, strict: bool = False):
         r"""
         :param get_or_method: a method-responsive-style dict. If a Responsive object is given, it will be GET handler
@@ -150,9 +150,9 @@ class Interface:
             it`s return value will be the final response
         :param strict: whether the interface will catch extra path in interfaces and return a 404 response
         :param desc: description about the interface. It will show instead of default message when calling __repr__
-        :param pre: things to do before processing request, it will be sent as final response
+        :param fpre: things to do before processing request, it will be sent as final response
             if a Response object is returned
-        :param post: things to do after the function processed request
+        :param fpost: things to do after the function processed request
         """
         if get_or_method is None:
             self.methods = {}
@@ -165,8 +165,8 @@ class Interface:
         self.methods: dict[Method, Responsive] = self.methods
         self.generic = generic
         self._fallback = fallback
-        self.pre = pre or []
-        self.post = post or []
+        self.fpre = fpre or []
+        self.fpost = fpost or []
         self.desc = desc
         self.strict = strict
 
@@ -209,7 +209,7 @@ class Interface:
             logging.warning(f'Request path {request.path} is out of root directory. Sending 404-Response instead')
             return Response(404)
 
-        for pre in self.pre:
+        for pre in self.fpre:
             res = pre(request)
             if isinstance(res, Request):
                 request = res
@@ -217,7 +217,7 @@ class Interface:
                 return Response.create_from(res)
 
         resp = Response.create_from(self._select_method(request))
-        for pst in self.post:
+        for pst in self.fpost:
             resp = Response.create_from(pst(request, resp))
         return resp
 


### PR DESCRIPTION
Currently, the method mapping should be explicitly specified in` __init__` method as the code paragragh below.
```python
class Foo(Interface):
    def __init__(self, *args, **kwargs):
        super().__init__({'GET': self.bar}, *args, **kwargs)  # mapping is specified here as {'GET': self.bar}
    def bar(self, request: Request) -> Sendable:
        # Do something
        return Response(content = 'something')
```
As the project scale increases, the mapping will be hard to read and analyze. It will be hard to figure out what method does a function handle.
Similar to many WSGI frameworks, we can introduce a feature to allow developers to define handlers with their method name in a class as the code paragragh below.
```python
class Foo(Interface):
    def get(self, request: Request) -> Sendable:  # specify method directly by name
        # Do something
        return Response(content = 'something')
```
As you can see, the code is reduced a lot. It helps clearify the logic of an application and make it easier to read and develop further.
